### PR TITLE
docs: fix relative paths/urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 `mrw` is a tool for managing multiple Git repositories in one workspace. It uses a yml file that lists the repositories and configurations of the workspace, allowing developers to clone and manage all repos with a single command. New contributors can start quickly by cloning the workspace and running `mrw init`.
 
 ## Docs
-For full documentation see [mrw documentation](https://github.com/maximeduf/multi-repo-workspace/blob/master/docs/README.md).
+For full documentation see [mrw documentation](./docs/README.md).
 
 ## Prerequisites
-for python prerequisites see [installation documentation](https://github.com/maximeduf/multi-repo-workspace/blob/master/docs/development/installation.md).
+for python prerequisites see [installation documentation](./docs/development/installation.md).
 
 ## Install and Run for development
 in venv activated
@@ -28,4 +28,4 @@ or
 ```
 
 ## Usage
-for usage, look at [quick-start.md](https://github.com/maximeduf/multi-repo-workspace/blob/master/docs/getting-started/quick-start.md).
+for usage, look at [quick-start.md](./docs/getting-started/quick-start.md).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 For full documentation see [mrw documentation](./docs/README.md).
 
 ## Prerequisites
-for python prerequisites see [installation documentation](./docs/development/installation.md).
+for python prerequisites see [installation documentation](./docs/getting-started/installation.md).
 
 ## Install and Run for development
 in venv activated

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -35,5 +35,5 @@ or
 `mrw -v`
 
 ## Next
-See [Quick Start Guide](quick-start.md).
+See [Quick Start Guide](../getting-started/quick-start.md).
 See [Contributing](./contributing.md).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,4 +16,4 @@ For [development, look here](../development/setup.md).
 `mrw -v`
 
 ## Next
-See [Quick Start Guide](quick-start.md).
+See [Quick Start Guide](./quick-start.md).


### PR DESCRIPTION
Fixed several "broken" paths. I used relative paths so that online or localy, we will be able to follow links within documentation.

For example :

![Screenshot from 2025-01-12 16-19-28](https://github.com/user-attachments/assets/89ec1a0e-8fb4-4701-835a-0e02090d9eaf)

![Screenshot from 2025-01-12 16-19-55](https://github.com/user-attachments/assets/26e11ffe-fa24-4dff-b92f-fce766d0c61f)

